### PR TITLE
Symbolics base class

### DIFF
--- a/pycollocation/__init__.py
+++ b/pycollocation/__init__.py
@@ -2,14 +2,16 @@
 Objects imported here will live in the `pycollocation` namespace
 
 """
-__all__ = ["BoundaryValueProblem", "OrthogonalPolynomialSolver", "Solution"]
+__all__ = ["SymbolicBoundaryValueProblem", "OrthogonalPolynomialSolver", "Solution"]
 
 
+from . import boundary_value_problems
+from . import differential_equations
 from . import models
 from . import orthogonal_polynomials
 from . import solutions
 
-from . models import BoundaryValueProblem
+from . boundary_value_problems import SymbolicBoundaryValueProblem
 from . orthogonal_polynomials import OrthogonalPolynomialSolver
 from . solutions import Solution
 

--- a/pycollocation/boundary_value_problems.py
+++ b/pycollocation/boundary_value_problems.py
@@ -1,0 +1,80 @@
+"""
+Classes for constructing two-point boundary value problems.
+
+@author : davidrpugh
+
+"""
+from . import differential_equations
+from . import symbolics
+
+
+class BoundaryValueProblem(object):
+
+    @property
+    def boundary_conditions(self):
+        """
+        Boundary conditions for the problem.
+
+        :getter: Return the boundary conditions for the problem.
+        :setter: Set new boundary conditions for the problem.
+        :type: dict
+
+        """
+        return self._boundary_conditions
+
+    @boundary_conditions.setter
+    def boundary_conditions(self, conditions):
+        """Set new boundary conditions for the model."""
+        self._boundary_conditions = self._validate_boundary(conditions)
+
+    def _sufficient_boundary(self, conditions):
+        """Check that there are sufficient boundary conditions."""
+        number_conditions = 0
+        if conditions['lower'] is not None:
+            number_conditions += len(conditions['lower'])
+        if conditions['upper'] is not None:
+            number_conditions += len(conditions['upper'])
+        return number_conditions == len(self.dependent_vars)
+
+    def _validate_boundary(self, conditions):
+        """Validate a dictionary of lower and upper boundary conditions."""
+        if not isinstance(conditions, dict):
+            mesg = "Attribute `boundary_conditions` must have type `dict` not {}"
+            raise AttributeError(mesg.format(conditions.__class__))
+        elif not (set(conditions.keys()) < set(['lower', 'upper', None])):
+            mesg = "Keys for `boundary_conditions` dict must be {}, {}, or {}"
+            raise AttributeError(mesg.format('lower', 'upper', 'None'))
+        elif not self._sufficient_boundary(conditions):
+            mesg = "Number of conditions must equal number of dependent vars."
+            raise ValueError(mesg)
+        else:
+            return conditions
+
+
+class SymbolicBoundaryValueProblem(BoundaryValueProblem,
+                                   symbolics.SymbolicBoundaryValueProblemLike,
+                                   differential_equations.SymbolicDifferentialEquation):
+    """Class for representing two-point boundary value problems."""
+
+    def __init__(self, boundary_conditions, dependent_vars, independent_var,
+                 rhs, params):
+        """Create an instance of a two-point boundary value problem (BVP)."""
+        super(SymbolicBoundaryValueProblem, self).__init__(dependent_vars,
+                                                           independent_var,
+                                                           rhs,
+                                                           params)
+        self.boundary_conditions = boundary_conditions
+
+    def _validate_boundary(self, conditions):
+        """Validate a dictionary of lower and upper boundary conditions."""
+        super(SymbolicBoundaryValueProblem, self)._validate_boundary(conditions)
+        bcs = {'lower': self._validate_boundary_exprs(conditions['lower']),
+               'upper': self._validate_boundary_exprs(conditions['upper'])}
+        return bcs
+
+    def _validate_boundary_exprs(self, expressions):
+        """Check that lower/upper boundary_conditions are expressions."""
+        if expressions is None:
+            return None
+        else:
+            return [self._validate_expression(expr) for expr in expressions]

--- a/pycollocation/differential_equations.py
+++ b/pycollocation/differential_equations.py
@@ -1,0 +1,62 @@
+"""
+Classes for constructing systems of ordinary differential equations.
+
+@author : davidrpugh
+
+"""
+import sympy as sym
+
+from . import models
+from . import symbolics
+
+
+class SymbolicDifferentialEquation(models.ModelLike,
+                                   symbolics.SymbolicModelLike):
+
+    _cached_rhs_functions = {}  # not sure if this is good practice!
+
+    def __init__(self, dependent_vars, independent_var, rhs, params):
+        """Create an instance of the DifferentialEquation class."""
+        self._dependent_vars = self._validate_symbols(dependent_vars)
+        self._independent_var = self._validate_symbol(independent_var)
+        self._rhs = self._validate_rhs(rhs)
+        self.params = self._validate_params(params)
+
+    def _rhs_functions(self, var):
+        """Cache lamdified rhs functions for numerical evaluation."""
+        if self._cached_rhs_functions.get(var) is None:
+            eqn = self.rhs[var]
+            self._cached_rhs_functions[var] = self._lambdify_factory(eqn)
+        return self._cached_rhs_functions[var]
+
+    @staticmethod
+    def _validate_expression(expression):
+        """Validates a symbolic expression."""
+        if not isinstance(expression, sym.Basic):
+            mesg = "Attribute must be of type `sympy.Basic` not {}"
+            raise AttributeError(mesg.format(expression.__class__))
+        else:
+            return expression
+
+    def _validate_rhs(self, rhs):
+        """Validate a the rhs attribute."""
+        super(SymbolicDifferentialEquation, self)._validate_rhs(rhs)
+        exprs = {}
+        for var, expr in rhs.items():
+            exprs[var] = self._validate_expression(expr)
+        else:
+            return exprs
+
+    @staticmethod
+    def _validate_symbol(symbol):
+        """Validate the independent_var attribute."""
+        if not isinstance(symbol, sym.Symbol):
+            mesg = "Attribute must be of type `sympy.Symbol` not {}"
+            raise AttributeError(mesg.format(symbol.__class__))
+        else:
+            return symbol
+
+    @classmethod
+    def _validate_symbols(cls, symbols):
+        """Validate the dependent_vars attribute."""
+        return [cls._validate_symbol(symbol) for symbol in symbols]

--- a/pycollocation/models.py
+++ b/pycollocation/models.py
@@ -5,14 +5,7 @@ import sympy as sym
 from . import symbolics
 
 
-class Model(object):
-
-    def __init__(self, dependent_vars, independent_var, rhs, params):
-        """Create an instance of the Model class."""
-        self._dependent_vars = self._validate_symbols(dependent_vars)
-        self._independent_var = self._validate_symbol(independent_var)
-        self._rhs = self._validate_rhs(rhs)
-        self.params = self._validate_params(params)
+class ModelLike(object):
 
     @property
     def dependent_vars(self):
@@ -72,15 +65,6 @@ class Model(object):
         return collections.OrderedDict(sorted(params.items()))
 
     @staticmethod
-    def _validate_expression(expression):
-        """Validates a symbolic expression."""
-        if not isinstance(expression, sym.Basic):
-            mesg = "Attribute must be of type `sympy.Basic` not {}"
-            raise AttributeError(mesg.format(expression.__class__))
-        else:
-            return expression
-
-    @staticmethod
     def _validate_params(value):
         """Validate the dictionary of parameters."""
         if not isinstance(value, dict):
@@ -90,7 +74,7 @@ class Model(object):
             return value
 
     def _validate_rhs(self, rhs):
-        """Validate a the rhs attribute."""
+        """Validate the rhs attribute."""
         if not isinstance(rhs, dict):
             mesg = "Attribute `rhs` must be of type `dict` not {}"
             raise AttributeError(mesg.format(rhs.__class__))
@@ -98,157 +82,4 @@ class Model(object):
             mesg = "Number of equations must equal number of dependent vars."
             raise ValueError(mesg)
         else:
-            exprs = {}
-            for var, expr in rhs.items():
-                exprs[var] = self._validate_expression(expr)
-            return exprs
-
-    @staticmethod
-    def _validate_symbol(symbol):
-        """Validate the independent_var attribute."""
-        if not isinstance(symbol, sym.Symbol):
-            mesg = "Attribute must be of type `sympy.Symbol` not {}"
-            raise AttributeError(mesg.format(symbol.__class__))
-        else:
-            return symbol
-
-    @classmethod
-    def _validate_symbols(cls, symbols):
-        """Validate the dependent_vars attribute."""
-        return [cls._validate_symbol(symbol) for symbol in symbols]
-
-
-class SymbolicModel(symbolics.SymbolicModelLike, Model):
-    """Base class for all symbolic models."""
-
-    _cached_rhs_functions = {}  # not sure if this is good practice!
-
-    def _rhs_functions(self, var):
-        """Cache lamdified rhs functions for numerical evaluation."""
-        if self._cached_rhs_functions.get(var) is None:
-            eqn = self.rhs[var]
-            self._cached_rhs_functions[var] = self._lambdify_factory(eqn)
-        return self._cached_rhs_functions[var]
-
-    def _validate_rhs(self, rhs):
-        """Validate a the rhs attribute."""
-        if not isinstance(rhs, dict):
-            mesg = "Attribute `rhs` must be of type `dict` not {}"
-            raise AttributeError(mesg.format(rhs.__class__))
-        elif not (len(rhs) == len(self.dependent_vars)):
-            mesg = "Number of equations must equal number of dependent vars."
-            raise ValueError(mesg)
-        else:
-            exprs = {}
-            for var, expr in rhs.items():
-                exprs[var] = self._validate_expression(expr)
-            return exprs
-
-    @staticmethod
-    def _validate_symbol(symbol):
-        """Validate the independent_var attribute."""
-        if not isinstance(symbol, sym.Symbol):
-            mesg = "Attribute must be of type `sympy.Symbol` not {}"
-            raise AttributeError(mesg.format(symbol.__class__))
-        else:
-            return symbol
-
-    @classmethod
-    def _validate_symbols(cls, symbols):
-        """Validate the dependent_vars attribute."""
-        return [cls._validate_symbol(symbol) for symbol in symbols]
-
-
-class DifferentialEquation(SymbolicModel):
-    pass
-
-
-class BoundaryValueProblem(DifferentialEquation):
-    """Class for representing two-point boundary value problems."""
-
-    __lower_boundary_condition = None
-
-    __upper_boundary_condition = None
-
-    def __init__(self, boundary_conditions, dependent_vars, independent_var,
-                 rhs, params):
-        """
-        Create an instance of a two-point boundary value problem (BVP).
-
-        """
-        super(BoundaryValueProblem, self).__init__(dependent_vars,
-                                                   independent_var,
-                                                   rhs,
-                                                   params)
-        self.boundary_conditions = boundary_conditions
-
-    @property
-    def _lower_boundary_condition(self):
-        """Cache lambdified lower boundary condition for numerical evaluation."""
-        condition = self.boundary_conditions['lower']
-        if condition is not None:
-            if self.__lower_boundary_condition is None:
-                self.__lower_boundary_condition = self._lambdify_factory(condition)
-            return self.__lower_boundary_condition
-        else:
-            return None
-
-    @property
-    def _upper_boundary_condition(self):
-        """Cache lambdified upper boundary condition for numerical evaluation."""
-        condition = self.boundary_conditions['upper']
-        if condition is not None:
-            if self.__upper_boundary_condition is None:
-                self.__upper_boundary_condition = self._lambdify_factory(condition)
-            return self.__upper_boundary_condition
-        else:
-            return None
-
-    @property
-    def boundary_conditions(self):
-        """
-        Boundary conditions for the problem.
-
-        :getter: Return the boundary conditions for the problem.
-        :setter: Set new boundary conditions for the problem.
-        :type: dict
-
-        """
-        return self._boundary_conditions
-
-    @boundary_conditions.setter
-    def boundary_conditions(self, conditions):
-        """Set new boundary conditions for the model."""
-        self._boundary_conditions = self._validate_boundary(conditions)
-
-    def _sufficient_boundary(self, conditions):
-        """Check that there are sufficient boundary conditions."""
-        number_conditions = 0
-        if conditions['lower'] is not None:
-            number_conditions += len(conditions['lower'])
-        if conditions['upper'] is not None:
-            number_conditions += len(conditions['upper'])
-        return number_conditions == len(self.dependent_vars)
-
-    def _validate_boundary(self, conditions):
-        """Validate a dictionary of lower and upper boundary conditions."""
-        if not isinstance(conditions, dict):
-            mesg = "Attribute `boundary_conditions` must have type `dict` not {}"
-            raise AttributeError(mesg.format(conditions.__class__))
-        elif not (set(conditions.keys()) < set(['lower', 'upper', None])):
-            mesg = "Keys for `boundary_conditions` dict must be {}, {}, or {}"
-            raise AttributeError(mesg.format('lower', 'upper', 'None'))
-        elif not self._sufficient_boundary(conditions):
-            mesg = "Number of conditions must equal number of dependent vars."
-            raise ValueError(mesg)
-        else:
-            bcs = {'lower': self._validate_boundary_exprs(conditions['lower']),
-                   'upper': self._validate_boundary_exprs(conditions['upper'])}
-            return bcs
-
-    def _validate_boundary_exprs(self, expressions):
-        """Check that lower/upper boundary_conditions are expressions."""
-        if expressions is None:
-            return None
-        else:
-            return [self._validate_expression(expr) for expr in expressions]
+            return rhs

--- a/pycollocation/models.py
+++ b/pycollocation/models.py
@@ -2,7 +2,7 @@ import collections
 
 import sympy as sym
 
-import symbolics
+from . import symbolics
 
 
 class Model(object):

--- a/pycollocation/solvers.py
+++ b/pycollocation/solvers.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import models
+from . import boundary_value_problems
 
 
 class Solver(object):
@@ -193,8 +193,8 @@ class Solver(object):
     @staticmethod
     def _validate_model(model):
         """Validate the dictionary of parameters."""
-        if not isinstance(model, models.BoundaryValueProblem):
-            mesg = "Attribute 'model' must have type models.BoundaryValueProblem, not {}"
+        if not isinstance(model, boundary_value_problems.BoundaryValueProblem):
+            mesg = "Attribute 'model' must have type BoundaryValueProblem, not {}"
             raise AttributeError(mesg.format(model.__class__))
         else:
             return model

--- a/pycollocation/symbolics.py
+++ b/pycollocation/symbolics.py
@@ -1,17 +1,43 @@
+"""
+Classes for constructing symbolic models.
+
+@author : davidrpugh
+
+"""
 import numpy as np
 import sympy as sym
 
 
-class SymbolicModelLike(object):
-
-    __symbolic_jacobian = None
+class SymbolicBase(object):
 
     _modules = [{'ImmutableMatrix': np.array}, 'numpy']
 
     @property
     def _symbolic_args(self):
         """List of symbolic arguments used to lambdify expressions."""
+        raise NotImplementedError
+
+    def _lambdify_factory(self, expr):
+        """Lambdify a symbolic expression."""
+        return sym.lambdify(self._symbolic_args, expr, self._modules)
+
+
+class SymbolicModelLike(SymbolicBase):
+
+    __symbolic_jacobian = None
+
+    @property
+    def _symbolic_args(self):
+        """List of symbolic arguments used to lambdify expressions."""
         return self._symbolic_vars + self._symbolic_params
+
+    @property
+    def _symbolic_jacobian(self):
+        """Symbolic Jacobian matrix of partial derivatives."""
+        if self.__symbolic_jacobian is None:
+            args = self.dependent_vars
+            self.__symbolic_jacobian = self._symbolic_system.jacobian(args)
+        return self.__symbolic_jacobian
 
     @property
     def _symbolic_params(self):
@@ -24,14 +50,6 @@ class SymbolicModelLike(object):
         return sym.Matrix([self.rhs[var] for var in self.dependent_vars])
 
     @property
-    def _symbolic_jacobian(self):
-        """Symbolic Jacobian matrix of partial derivatives."""
-        if self.__symbolic_jacobian is None:
-            args = self.dependent_vars
-            self.__symbolic_jacobian = self._symbolic_system.jacobian(args)
-        return self.__symbolic_jacobian
-
-    @property
     def _symbolic_vars(self):
         """List of symbolic model variables."""
         return [self.independent_var] + self.dependent_vars
@@ -40,6 +58,44 @@ class SymbolicModelLike(object):
         """Clear cached symbolic Jacobian."""
         self.__symbolic_jacobian = None
 
-    def _lambdify_factory(self, expr):
-        """Lambdify a symbolic expression."""
-        return sym.lambdify(self._symbolic_args, expr, self._modules)
+
+class SymbolicBoundaryValueProblemLike(SymbolicModelLike):
+
+    __lower_boundary_condition = None
+
+    __upper_boundary_condition = None
+
+    @property
+    def _lower_boundary_condition(self):
+        """Cache lambdified lower boundary condition for numerical evaluation."""
+        condition = self.boundary_conditions['lower']
+        if condition is not None:
+            if self.__lower_boundary_condition is None:
+                self.__lower_boundary_condition = self._lambdify_factory(condition)
+            return self.__lower_boundary_condition
+        else:
+            return None
+
+    @property
+    def _upper_boundary_condition(self):
+        """Cache lambdified upper boundary condition for numerical evaluation."""
+        condition = self.boundary_conditions['upper']
+        if condition is not None:
+            if self.__upper_boundary_condition is None:
+                self.__upper_boundary_condition = self._lambdify_factory(condition)
+            return self.__upper_boundary_condition
+        else:
+            return None
+
+    def _validate_boundary(self, conditions):
+        """Validate a dictionary of lower and upper boundary conditions."""
+        bcs = {'lower': self._validate_boundary_exprs(conditions['lower']),
+               'upper': self._validate_boundary_exprs(conditions['upper'])}
+        return bcs
+
+    def _validate_boundary_exprs(self, expressions):
+        """Check that lower/upper boundary_conditions are expressions."""
+        if expressions is None:
+            return None
+        else:
+            return [self._validate_expression(expr) for expr in expressions]

--- a/pycollocation/symbolics.py
+++ b/pycollocation/symbolics.py
@@ -1,0 +1,26 @@
+import numpy as np
+import sympy as sym
+
+
+class Symbolics(object):
+
+    _modules = [{'ImmutableMatrix': np.array}, 'numpy']
+
+    @property
+    def _symbolic_args(self):
+        """List of symbolic arguments used to lambdify expressions."""
+        return self._symbolic_vars + self._symbolic_params
+
+    @property
+    def _symbolic_params(self):
+        """List of symbolic model parameters."""
+        return sym.var(list(self.params.keys()))
+
+    @property
+    def _symbolic_vars(self):
+        """List of symbolic model variables."""
+        return [self.independent_var] + self.dependent_vars
+
+    def _lambdify_factory(self, expr):
+        """Lambdify a symbolic expression."""
+        return sym.lambdify(self._symbolic_args, expr, self._modules)

--- a/pycollocation/symbolics.py
+++ b/pycollocation/symbolics.py
@@ -2,7 +2,9 @@ import numpy as np
 import sympy as sym
 
 
-class Symbolics(object):
+class SymbolicModelLike(object):
+
+    __symbolic_jacobian = None
 
     _modules = [{'ImmutableMatrix': np.array}, 'numpy']
 
@@ -17,9 +19,26 @@ class Symbolics(object):
         return sym.var(list(self.params.keys()))
 
     @property
+    def _symbolic_system(self):
+        """Represents rhs as a symbolic matrix."""
+        return sym.Matrix([self.rhs[var] for var in self.dependent_vars])
+
+    @property
+    def _symbolic_jacobian(self):
+        """Symbolic Jacobian matrix of partial derivatives."""
+        if self.__symbolic_jacobian is None:
+            args = self.dependent_vars
+            self.__symbolic_jacobian = self._symbolic_system.jacobian(args)
+        return self.__symbolic_jacobian
+
+    @property
     def _symbolic_vars(self):
         """List of symbolic model variables."""
         return [self.independent_var] + self.dependent_vars
+
+    def _clear_cache(self):
+        """Clear cached symbolic Jacobian."""
+        self.__symbolic_jacobian = None
 
     def _lambdify_factory(self, expr):
         """Lambdify a symbolic expression."""

--- a/pycollocation/test/test_polynomial_collocation.py
+++ b/pycollocation/test/test_polynomial_collocation.py
@@ -3,8 +3,8 @@ import unittest
 import numpy as np
 import sympy as sym
 
-from .. import models
-from .. import orthogonal_polynomials
+from .. boundary_value_problems import SymbolicBoundaryValueProblem
+from .. orthogonal_polynomials import OrthogonalPolynomialSolver
 from .. import solutions
 
 
@@ -49,14 +49,14 @@ class SolowModel(unittest.TestCase):
         bcs = {'lower': [k - k0], 'upper': None}
 
         # set the model instance
-        self.model = models.BoundaryValueProblem(dependent_vars=[k],
-                                                 independent_var=t,
-                                                 rhs=rhs,
-                                                 boundary_conditions=bcs,
-                                                 params=self.params)
+        self.model = SymbolicBoundaryValueProblem(dependent_vars=[k],
+                                                  independent_var=t,
+                                                  rhs=rhs,
+                                                  boundary_conditions=bcs,
+                                                  params=self.params)
 
         # set the solver instance
-        self.solver = orthogonal_polynomials.OrthogonalPolynomialSolver(self.model)
+        self.solver = OrthogonalPolynomialSolver(self.model)
 
         # set the domain
         self.domain = [0, 100]

--- a/pycollocation/test/test_polynomial_collocation.py
+++ b/pycollocation/test/test_polynomial_collocation.py
@@ -11,7 +11,18 @@ from .. import solutions
 class SolowModel(unittest.TestCase):
 
     @staticmethod
-    def steady_state(g, n, s, alpha, delta, sigma):
+    def analytic_solution(k0, t, g, n, s, alpha, delta, sigma=1.0):
+        """Analytic solution for model with Cobb-Douglas production."""
+        # lambda governs the speed of convergence
+        lmbda = (g + n + delta) * (1 - alpha)
+
+        # analytic solution for Solow model at time t
+        ks = (((s / (g + n + delta)) * (1 - np.exp(-lmbda * t)) +
+               k0**(1 - alpha) * np.exp(-lmbda * t))**(1 / (1 - alpha)))
+        return ks
+
+    @staticmethod
+    def steady_state(g, n, s, alpha, delta, sigma=1.0):
         """Steady state value for capital (per unit effective labor)."""
         return (s / (g + n + delta))**(1 / (1 - alpha))
 
@@ -43,10 +54,10 @@ class SolowModel(unittest.TestCase):
         # specify some boundary conditions
         kstar = self.steady_state(**self.params)
         if np.random.uniform() < 0.5:
-            k0 = 0.5 * kstar
+            self.k0 = 0.5 * kstar
         else:
-            k0 = 2.0 * kstar
-        bcs = {'lower': [k - k0], 'upper': None}
+            self.k0 = 2.0 * kstar
+        bcs = {'lower': [k - self.k0], 'upper': None}
 
         # set the model instance
         self.model = SymbolicBoundaryValueProblem(dependent_vars=[k],
@@ -63,7 +74,7 @@ class SolowModel(unittest.TestCase):
 
         # set an initial guess
         ts = np.linspace(self.domain[0], self.domain[1], 1000)
-        ks = kstar - (kstar - k0) * np.exp(-ts)
+        ks = kstar - (kstar - self.k0) * np.exp(-ts)
         initial_guess = np.polynomial.Chebyshev.fit(ts, ks, 50, self.domain)
         self.initial_coefs = {k: initial_guess.coef}
 
@@ -89,6 +100,13 @@ class SolowModel(unittest.TestCase):
         self.assertTrue(np.mean(residuals) < 1e-6,
                         msg=mesg.format(residuals, self.params))
 
+        # check that the numerical and analytic solutions are close
+        numeric_soln = solution.solution.ix[:, 0]
+        analytic_soln = self.analytic_solution(self.k0,
+                                               solution.interpolation_knots,
+                                               **self.params)
+        self.assertTrue(np.mean(numeric_soln - analytic_soln) < 1e-6)
+
     def test_legendre_collocation(self):
         """Test collocation solver using Legendre polynomials for basis."""
         self.solver.solve(kind="Legendre",
@@ -109,3 +127,10 @@ class SolowModel(unittest.TestCase):
         mesg = "Legendre residuals:\n{}\n\nDictionary of model params: {}"
         self.assertTrue(np.mean(residuals) < 1e-6,
                         msg=mesg.format(residuals, self.params))
+
+        # check that the numerical and analytic solutions are close
+        numeric_soln = solution.solution.ix[:, 0]
+        analytic_soln = self.analytic_solution(self.k0,
+                                               solution.interpolation_knots,
+                                               **self.params)
+        self.assertTrue(np.mean(numeric_soln - analytic_soln) < 1e-6)


### PR DESCRIPTION
Continue to separate implementation of symbolics from rest of the code by creating a `SymbolicModelLike` class.
